### PR TITLE
Added check before forcing JSON.stringify

### DIFF
--- a/lib/truevault.js
+++ b/lib/truevault.js
@@ -2,12 +2,24 @@ var restify = require('restify');
 
 var ENDPOINT = 'https://api.truevault.com';
 
+function isJSON(str) {
+	try {
+		JSON.parse(str);
+	} catch (e) {
+		return false;
+	}
+	return true;
+}
 
 var base64Encode = function(document) {
 	if (typeof document == 'string') {
 		return document;
 	} else if (typeof document == 'object') {
-		return new Buffer(JSON.stringify(document)).toString('base64');
+		if (isJSON(document)) {
+			return new Buffer(document).toString('base64');
+		} else {
+			return new Buffer(JSON.stringify(document)).toString('base64');
+		}
 	} else {
 		return String.valueOf(document);
 	}


### PR DESCRIPTION
When starting with the module I was passing already `stringify`'d data through and only getting a `400` code error returned. I realized my issue after a few minutes, however, I could see this being an issue for others.

The changes simply add a check before running `JSON.stringify()` in the `base64Encode` method.
